### PR TITLE
Add zpool to pools.json

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -13,5 +13,12 @@
             "/stratum/",
             "/nodeStratum/"
         ]
+    },
+    {
+        "poolName": "zpool",
+        "url": "https://zpool.ca/",
+        "searchStrings": [
+            "/www.zpool.ca/"
+        ]
     }
 ]


### PR DESCRIPTION
Add zpool to the list of pools shown in Insight, coinbase will include "www.zpool.ca".
This can be seen in block #891611,  tx e4cf2220dfda02fdc9466fdce8b8f1cd94677966bc9c79f8a514e5837f851c1c