### PR TITLE
Add pool identification by output address

### DIFF
--- a/addresses.json
+++ b/addresses.json
@@ -1,0 +1,27 @@
+[
+	{
+		"poolName": "yiimp.eu",
+		"address": "VbnKqcsnXUYn6iPgZc7qb6fXVKd4i3UWM3",
+		"url": "http://yiimp.eu"
+	},
+	{
+		"poolName": "Suprnova.cc",
+		"address": "VwDR2x5AZxvKJejtWKiYhrMiZHr5HPVxZv",
+		"url": "http://vtc.suprnova.cc"
+	},
+	{
+		"poolName": "Zergpool",
+		"address": "VrdN5UoPynUrtYoqWBXsBhN9Hta2pSZaLL",
+		"url": "http://zergpool.com"
+	},
+	{
+		"poolName": "HashRefinery",
+		"address": "VcV8vPAybuTqzZoR9UksM219gRiTHaE3gi",
+		"url": "http://pool.hashrefinery.com"
+	},
+	{
+		"poolName": "Coinotron",
+		"address": "VpYQTF5W927YRNxP9osKTTqH3qi8R2r4sB",
+		"url": "http://coinotron.com"
+	}
+]

--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -6,6 +6,7 @@ var util = require('util');
 var vertcore = require('vertcore-lib');
 var _ = vertcore.deps._;
 var pools = require('../pools.json');
+var addresses = require('../addresses.json');
 var LRU = require('lru-cache');
 var Common = require('./common');
 var vcoin = require('vcoin');
@@ -342,12 +343,25 @@ BlockController.prototype.getPoolInfo = function(tx) {
   if (!tx) {
     return {};
   }
+
+  var outputAddress = tx.outputs[0].address;
+
+  for(var k in addresses) {
+    if (outputAddress === addresses[k].address) {
+      return addresses[k];
+    }
+  }
+
   var coinbaseBuffer = tx.inputs[0].script.raw;
 
   for(var k in this.poolStrings) {
     if (coinbaseBuffer.toString('utf-8').match(k)) {
       return this.poolStrings[k];
     }
+  }
+
+  if (tx.outputs.length > 1) {
+    return { "poolName": "P2Pool", "url": "https://vertcoin.org" };
   }
 
   return {};


### PR DESCRIPTION
Checks the outputs of the transaction for known pool addresses specified
in addresses.json. Returns P2Pool is there are more than 1 output
addresses in the transaction.