### PR TITLE
Add address parsing support to getPoolInfo

### DIFF
--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -342,10 +342,23 @@ BlockController.prototype.getPoolInfo = function(tx) {
   if (!tx) {
     return {};
   }
+  
+  var addresses = [];
+
+  for(var i in tx.outputs) {
+    var address = tx.outputs[i].script.getAddress();
+    if(address != null) {
+      addresses.push(address.toString('main'));
+    }
+  }
+  
   var coinbaseBuffer = tx.inputs[0].script.raw;
 
   for(var k in this.poolStrings) {
     if (coinbaseBuffer.toString('utf-8').match(k)) {
+      return this.poolStrings[k];
+    }
+    if(addresses.includes(k)) {
       return this.poolStrings[k];
     }
   }


### PR DESCRIPTION
This allows payout addresses to be used for identifying mining pools.